### PR TITLE
🔧 調整 Drone CI/CD 配置與環境變數管理

### DIFF
--- a/.drone.jsonnet
+++ b/.drone.jsonnet
@@ -4,8 +4,8 @@
 
 local VALUES = {
   PROJECT_NAME:             "heron",
-  DOCKERHUB_USER:           "popopopony",
-  DOCKERHUB_IMAGE:          "popopopony/heron",
+  DOCKERHUB_USER:           "lislab3morris",
+  DOCKERHUB_IMAGE:          "lislab3morris/heron",
   K8S_DEPLOYMENT_NAME:      "heron",
   K8S_DEPLOYMENT_NAMESPACE: "heron",
   CONTAINER_NAME:           "heron",
@@ -15,11 +15,11 @@ local VALUES = {
 
 
 local SECRET = {
-  K8S_SERVER:           { from_secret: "K8S_SERVER" },
-  K8S_TOKEN:            { from_secret: "K8S_TOKEN" },
-  K8S_CA:               { from_secret: "K8S_CA" },
-  DOCKER_USERNAME:      { from_secret: "DOCKER_USERNAME_pony" },
-  DOCKER_PASSWORD:      { from_secret: "DOCKER_PASSWORD_pony" },
+  K8S_SERVER:           { from_secret: "k8s-server" },
+  K8S_TOKEN:            { from_secret: "k8s-token" },
+  K8S_CA:               { from_secret: "k8s-ca" },
+  DOCKER_USERNAME:      { from_secret: "docker-username" },
+  DOCKER_PASSWORD:      { from_secret: "docker-password" },
 };
 
 
@@ -44,8 +44,9 @@ local deploy_pipeline = {
         tags: ["latest", "${DRONE_COMMIT_SHA}"],
         username: SECRET.DOCKER_USERNAME,
         password: SECRET.DOCKER_PASSWORD,
+        cache_from: [VALUES.DOCKERHUB_IMAGE + ":latest"],
         build_args: [
-          "WALRUS_API_BASE_URL=https://lab3-walrus.ddns.net",
+          "WALRUS_API_BASE_URL=https://walrus.lab3.website",
           "ENV=staging",
           "APP_TITLE=Heron"
         ],

--- a/.drone.yml
+++ b/.drone.yml
@@ -7,30 +7,32 @@
   "name": "build and push docker image"
   "settings":
     "build_args":
-    - "WALRUS_API_BASE_URL=https://lab3-walrus.ddns.net"
+    - "WALRUS_API_BASE_URL=https://walrus.lab3.website"
     - "ENV=staging"
     - "APP_TITLE=Heron"
+    "cache_from":
+    - "lislab3morris/heron:latest"
     "password":
-      "from_secret": "DOCKER_PASSWORD_pony"
-    "repo": "popopopony/heron"
+      "from_secret": "docker-password"
+    "repo": "lislab3morris/heron"
     "tags":
     - "latest"
     - "${DRONE_COMMIT_SHA}"
     "username":
-      "from_secret": "DOCKER_USERNAME_pony"
+      "from_secret": "docker-username"
 - "commands":
-  - "kubectl set image deployment/heron heron=popopopony/heron:${DRONE_COMMIT_SHA} --namespace=heron || exit 1"
+  - "kubectl set image deployment/heron heron=lislab3morris/heron:${DRONE_COMMIT_SHA} --namespace=heron || exit 1"
   - "kubectl rollout status deployment/heron --namespace=heron || exit 1"
   - "echo Deployment success!"
   "image": "sinlead/drone-kubectl"
   "name": "deploy to k8s"
   "settings":
     "kubernetes_cert":
-      "from_secret": "K8S_CA"
+      "from_secret": "k8s-ca"
     "kubernetes_server":
-      "from_secret": "K8S_SERVER"
+      "from_secret": "k8s-server"
     "kubernetes_token":
-      "from_secret": "K8S_TOKEN"
+      "from_secret": "k8s-token"
     "namespace": "heron"
     "startTimeout": 240
 "trigger":

--- a/.gitignore
+++ b/.gitignore
@@ -20,10 +20,7 @@ auto-imports.d.ts
 components.d.ts
 
 # Environment variables (如果有敏感資訊請 uncomment)
-# env/
-# *.env
-# *.env.local
-# *.env.*.local
+env/.env.local
 
 # Logs
 logs

--- a/env/.env.example
+++ b/env/.env.example
@@ -1,0 +1,3 @@
+WALRUS_API_BASE_URL=https://walrus.example.com
+ENV=local
+APP_TITLE=Heron

--- a/env/heron-local.env
+++ b/env/heron-local.env
@@ -1,3 +1,0 @@
-WALRUS_API_BASE_URL=http://localhost:8000/
-ENV=local
-APP_TITLE=Heron

--- a/env/heron-staging.env
+++ b/env/heron-staging.env
@@ -1,3 +1,0 @@
-WALRUS_API_BASE_URL=https://lab3-walrus.ddns.net/
-ENV=staging
-APP_TITLE=Heron

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -7,7 +7,7 @@ import Components from 'unplugin-vue-components/vite'
 // https://vitejs.dev/config/
 export default defineConfig(({ mode }) => {
   // 載入環境變數
-  const env = loadEnv(mode, process.cwd(), '')
+  const env = loadEnv(mode, resolve(__dirname, 'env'), '')
 
   return {
   // 將環境變數注入到客戶端代碼


### PR DESCRIPTION
更新 Drone CI/CD 配置：
- 將 DockerHub 帳戶與映像路徑更新至 lislab3morris。
- 標準化 Kubernetes 密鑰名稱。
- 更新 Walrus API 基礎 URL。
- 新增 Docker 映像建置快取以提升 CI/CD 效能。

重構環境變數管理：
- 刪除特定環境檔案 (heron-local.env, heron-staging.env)。
- 新增 env/.env.example 作為環境變數範本。
- 更新 .gitignore 以忽略 env/.env.local。
- 修改 vite.config.ts 以從 env 目錄載入環境變數。

此變更旨在：
- 遷移至新的 DockerHub 帳戶與標準化 K8s 密鑰命名。
- 更新 Walrus API 端點至正確的生產環境 URL。
- 透過快取加速 CI/CD 流程。
- 採用更標準化的環境變數管理方式，提供清晰範本並允許本地覆寫， 避免提交敏感資訊。