### PR TITLE
🔧✨ feat(ci, spotify): 更新 CI/CD 配置並強化 Spotify 授權處理

### DIFF
--- a/.drone.jsonnet
+++ b/.drone.jsonnet
@@ -15,16 +15,10 @@ local VALUES = {
 
 
 local SECRET = {
-  K8S_SERVER:           { from_secret: "k8s-server" },
-  K8S_TOKEN:            { from_secret: "k8s-token" },
-  K8S_CA:               { from_secret: "k8s-ca" },
   DOCKER_USERNAME:      { from_secret: "docker-username" },
   DOCKER_PASSWORD:      { from_secret: "docker-password" },
 };
 
-local secret_k8s_server =    { kind: "secret", name: "k8s-server",      get: { path: "k8s-server",      name: "value" } };
-local secret_k8s_token =     { kind: "secret", name: "k8s-token",       get: { path: "k8s-token",       name: "value" } };
-local secret_k8s_ca =        { kind: "secret", name: "k8s-ca",          get: { path: "k8s-ca",          name: "value" } };
 local secret_docker_user =   { kind: "secret", name: "docker-username", get: { path: "docker-username", name: "value" } };
 local secret_docker_pass =   { kind: "secret", name: "docker-password", get: { path: "docker-password", name: "value" } };
 
@@ -62,14 +56,7 @@ local deploy_pipeline = {
     },
     {
       name:  "deploy to k8s",
-      image: "sinlead/drone-kubectl",
-      settings: {
-        kubernetes_server: SECRET.K8S_SERVER,
-        kubernetes_token:  SECRET.K8S_TOKEN,
-        kubernetes_cert:   SECRET.K8S_CA,
-        namespace: VALUES.K8S_DEPLOYMENT_NAMESPACE,
-        startTimeout: 240
-      },
+      image: "bitnami/kubectl",
       commands: [
         std.format(
           "kubectl set image deployment/%s %s=%s:${DRONE_COMMIT_SHA} --namespace=%s || exit 1",
@@ -87,5 +74,5 @@ local deploy_pipeline = {
 
 std.join("\n---\n", [
   std.manifestYamlDoc(p)
-  for p in [deploy_pipeline, secret_k8s_server, secret_k8s_token, secret_k8s_ca, secret_docker_user, secret_docker_pass]
+  for p in [deploy_pipeline, secret_docker_user, secret_docker_pass]
 ])

--- a/.drone.yml
+++ b/.drone.yml
@@ -10,6 +10,8 @@
     - "WALRUS_API_BASE_URL=https://walrus.lab3.website"
     - "ENV=staging"
     - "APP_TITLE=Heron"
+    - "BUILDKIT_INLINE_CACHE=1"
+    "buildkit": true
     "cache_from":
     - "lislab3morris/heron:latest"
     "password":
@@ -24,41 +26,14 @@
   - "kubectl set image deployment/heron heron=lislab3morris/heron:${DRONE_COMMIT_SHA} --namespace=heron || exit 1"
   - "kubectl rollout status deployment/heron --namespace=heron || exit 1"
   - "echo Deployment success!"
-  "image": "sinlead/drone-kubectl"
+  "image": "bitnami/kubectl"
   "name": "deploy to k8s"
-  "settings":
-    "kubernetes_cert":
-      "from_secret": "k8s-ca"
-    "kubernetes_server":
-      "from_secret": "k8s-server"
-    "kubernetes_token":
-      "from_secret": "k8s-token"
-    "namespace": "heron"
-    "startTimeout": 240
 "trigger":
   "branch":
   - "master"
   "event":
   - "push"
 "type": "kubernetes"
----
-"get":
-  "name": "value"
-  "path": "k8s-server"
-"kind": "secret"
-"name": "k8s-server"
----
-"get":
-  "name": "value"
-  "path": "k8s-token"
-"kind": "secret"
-"name": "k8s-token"
----
-"get":
-  "name": "value"
-  "path": "k8s-ca"
-"kind": "secret"
-"name": "k8s-ca"
 ---
 "get":
   "name": "value"

--- a/src/services/api.ts
+++ b/src/services/api.ts
@@ -20,6 +20,11 @@ export const clearTokens = (): void => {
   sessionStorage.removeItem('refresh_token')
 }
 
+export const RESPONSE_CODE = {
+  SUCCESS: 2000,
+  REAUTH_REQUIRED: 6003,
+} as const
+
 // API 響應類型定義
 export interface ApiResponse<T = any> {
   code: number
@@ -138,6 +143,13 @@ export const getSpotifyToken = async (): Promise<ApiResponse<SpotifyTokenRespons
   return apiRequest<SpotifyTokenResponse>('spotifyToken', {
     method: 'GET',
   })
+}
+
+export const redirectToSpotifyReauth = async (): Promise<void> => {
+  const authResponse = await getSpotifyAuthUrl()
+  if (authResponse.data?.spotify_authorize_url) {
+    window.location.href = authResponse.data.spotify_authorize_url
+  }
 }
 
 // 處理 Spotify OAuth 授權碼 API

--- a/src/stores/spotifyPlayer.ts
+++ b/src/stores/spotifyPlayer.ts
@@ -1,6 +1,7 @@
 import { defineStore } from 'pinia'
 import { ref } from 'vue'
 import { getUserData, setUserData, USER_DATA_KEYS } from '@/utils/userStorage'
+import { RESPONSE_CODE, redirectToSpotifyReauth } from '@/services/api'
 
 export const useSpotifyPlayerStore = defineStore('spotifyPlayer', () => {
   const spotifyPlayer = ref<any>(null)
@@ -51,6 +52,13 @@ export const useSpotifyPlayerStore = defineStore('spotifyPlayer', () => {
       }
 
       const newTokenData = await response.json()
+
+      if (newTokenData.code === RESPONSE_CODE.REAUTH_REQUIRED) {
+        console.warn('[SpotifyStore] Reauth required, redirecting to Spotify OAuth...')
+        await redirectToSpotifyReauth()
+        return false
+      }
+
       const accessToken = newTokenData.data?.access_token || newTokenData.access_token
 
       if (!accessToken) {

--- a/src/views/SpotifyCallback.vue
+++ b/src/views/SpotifyCallback.vue
@@ -82,7 +82,7 @@
 import { ref, onMounted } from 'vue'
 import { useRouter, useRoute } from 'vue-router'
 import { getUserData, setUserData, USER_DATA_KEYS } from '@/utils/userStorage'
-import { getSpotifyToken } from '@/services/api'
+import { getSpotifyToken, RESPONSE_CODE, redirectToSpotifyReauth } from '@/services/api'
 
 const router = useRouter()
 const route = useRoute()
@@ -124,7 +124,13 @@ const handleAuthCallback = async () => {
     try {
       const tokenResponse = await getSpotifyToken()
 
-      if (tokenResponse.code === 2000 && tokenResponse.data &&
+      if (tokenResponse.code === RESPONSE_CODE.REAUTH_REQUIRED) {
+        console.warn('Reauth required after callback, redirecting to Spotify OAuth...')
+        await redirectToSpotifyReauth()
+        return
+      }
+
+      if (tokenResponse.code === RESPONSE_CODE.SUCCESS && tokenResponse.data &&
           (tokenResponse.data.access_token || tokenResponse.data.spotify_access_token)) {
         // 授權成功，有 token
         authStatus.value = 'success'

--- a/src/views/SpotifyPreAuth.vue
+++ b/src/views/SpotifyPreAuth.vue
@@ -839,7 +839,7 @@
 <script setup lang="ts">
 import { ref, onMounted, nextTick } from 'vue'
 // import { useRouter } from 'vue-router'
-import { loginUser, getSpotifyAuthUrl, getSpotifyToken, validatePlaylist, importPlaylist, cachePlaylistOrder, getAccessToken, checkPlaylist } from '@/services/api'
+import { loginUser, getSpotifyAuthUrl, getSpotifyToken, validatePlaylist, importPlaylist, cachePlaylistOrder, getAccessToken, checkPlaylist, RESPONSE_CODE, redirectToSpotifyReauth } from '@/services/api'
 import ParticleBackground from '@/components/ParticleBackground.vue'
 import { setCurrentUserEmail, setUserData, getUserData, USER_DATA_KEYS } from '@/utils/userStorage'
 
@@ -945,7 +945,13 @@ const handleEmailLogin = async () => {
         console.log('Checking if Spotify token already exists...')
         const tokenResponse = await getSpotifyToken()
 
-        if (tokenResponse.code === 2000 && tokenResponse.data &&
+        if (tokenResponse.code === RESPONSE_CODE.REAUTH_REQUIRED) {
+          console.warn('Reauth required, redirecting to Spotify OAuth...')
+          await redirectToSpotifyReauth()
+          return
+        }
+
+        if (tokenResponse.code === RESPONSE_CODE.SUCCESS && tokenResponse.data &&
             (tokenResponse.data.access_token || tokenResponse.data.spotify_access_token)) {
           // 已經有 token，不需要重新授權，直接檢查步驟完成狀態
           console.log('Spotify token already exists, skipping authorization')
@@ -1016,14 +1022,20 @@ const verifyAuthStatus = async () => {
       // 如果沒有 token，調用 API 獲取
       const response = await getSpotifyToken()
 
-      if (response.code === 2000 || response.code === 200) {
+      if (response.code === RESPONSE_CODE.REAUTH_REQUIRED) {
+        console.warn('Reauth required, redirecting to Spotify OAuth...')
+        await redirectToSpotifyReauth()
+        return
+      }
+
+      if (response.code === RESPONSE_CODE.SUCCESS) {
         // 檢查回應中是否有 data 和 access_token
         if (response.data && response.data.access_token && response.data.access_token.trim() !== '') {
           // 成功獲得了有效的 Spotify token，表示授權成功
 
           // 儲存到用戶資料
           setUserData(USER_DATA_KEYS.SPOTIFY_ACCESS_TOKEN, response.data.access_token)
-          
+
           // 強制觸發慶祝效果
           await forceTriggerCelebration()
         } else {
@@ -1406,7 +1418,14 @@ const checkStepCompletion = async () => {
     let hasSpotifyToken = false
     try {
       const tokenResponse = await getSpotifyToken()
-      hasSpotifyToken = !!(tokenResponse.code === 2000 &&
+
+      if (tokenResponse.code === RESPONSE_CODE.REAUTH_REQUIRED) {
+        console.warn('Reauth required, redirecting to Spotify OAuth...')
+        await redirectToSpotifyReauth()
+        return
+      }
+
+      hasSpotifyToken = !!(tokenResponse.code === RESPONSE_CODE.SUCCESS &&
                         tokenResponse.data &&
                         (tokenResponse.data.access_token || tokenResponse.data.spotify_access_token))
       console.log('Spotify token API check:', tokenResponse, 'hasSpotifyToken:', hasSpotifyToken)


### PR DESCRIPTION
WHAT:
* **CI/CD 配置 (.drone.jsonnet, .drone.yml):**
 * 移除 Kubernetes 相關的秘密配置與部署步驟中的認證設定。
 * 將部署步驟的 kubectl 映像檔更換為 `bitnami/kubectl`。
 * 為 Docker 映像檔建置步驟啟用 BuildKit 內聯快取。
* **Spotify 授權處理 (src/services/api.ts, src/stores/spotifyPlayer.ts, views):**
 * 新增 `RESPONSE_CODE` 常數，定義 API 成功 (2000) 與重新授權 (6003) 代碼。
 * 新增 `redirectToSpotifyReauth` 輔助函數，用於導向 Spotify 授權頁面。
 * 在 Spotify 播放器儲存庫、回調頁面和預授權頁面中，整合了當 API 回應 `REAUTH_REQUIRED` 時，自動導向 Spotify 重新授權的邏輯。
 * 將硬編碼的 `2000` 成功代碼替換為 `RESPONSE_CODE.SUCCESS`。

WHY:
* **CI/CD 配置：**
 * 簡化 Kubernetes 部署的認證機制，可能改為依賴服務帳戶。
 * 使用 `bitnami/kubectl` 映像檔可能提供更好的維護性。
 * 啟用 BuildKit 快取以加速 Docker 映像檔的建置時間。
* **Spotify 授權處理：**
 * 標準化 API 回應代碼的處理，提高代碼可讀性與維護性。
 * 提供健壯機制處理 Spotify 存取權杖過期，透過自動引導用戶重新授權， 改善用戶體驗並減少錯誤。
 * 確保在應用程式的各個關鍵點都能一致地處理 Spotify 重新授權需求。