### PR TITLE
♻️ 重構(auth)：優化Spotify重新驗證流程與快取清除

### DIFF
--- a/src/services/api.ts
+++ b/src/services/api.ts
@@ -20,8 +20,8 @@ export const clearTokens = (): void => {
   sessionStorage.removeItem('refresh_token')
 }
 
-export const clearSpotifyCache = (): void => {
-  sessionStorage.removeItem('spotifyAccessToken')
+export const clearAllCache = (): void => {
+  sessionStorage.clear()
   localStorage.removeItem('trackInfoCache_v3')
 }
 
@@ -121,7 +121,7 @@ const apiRequest = async <T>(
     console.log('Response data:', data)
 
     if (!skipReauth && data.code === RESPONSE_CODE.REAUTH_REQUIRED) {
-      await redirectToSpotifyReauth()
+      redirectToSpotifyReauth()
     }
 
     return data
@@ -154,12 +154,9 @@ export const getSpotifyToken = async (): Promise<ApiResponse<SpotifyTokenRespons
   })
 }
 
-export const redirectToSpotifyReauth = async (): Promise<void> => {
-  clearSpotifyCache()
-  const authResponse = await getSpotifyAuthUrl()
-  if (authResponse.data?.spotify_authorize_url) {
-    window.location.href = authResponse.data.spotify_authorize_url
-  }
+export const redirectToSpotifyReauth = (): void => {
+  clearAllCache()
+  window.location.href = '/spotify-pre-auth'
 }
 
 // 處理 Spotify OAuth 授權碼 API

--- a/src/views/SpotifyPreAuth.vue
+++ b/src/views/SpotifyPreAuth.vue
@@ -947,7 +947,7 @@ const handleEmailLogin = async () => {
 
         if (tokenResponse.code === RESPONSE_CODE.REAUTH_REQUIRED) {
           console.warn('Reauth required, redirecting to Spotify OAuth...')
-          await redirectToSpotifyReauth()
+          redirectToSpotifyReauth()
           return
         }
 
@@ -1024,7 +1024,7 @@ const verifyAuthStatus = async () => {
 
       if (response.code === RESPONSE_CODE.REAUTH_REQUIRED) {
         console.warn('Reauth required, redirecting to Spotify OAuth...')
-        await redirectToSpotifyReauth()
+        redirectToSpotifyReauth()
         return
       }
 
@@ -1421,7 +1421,7 @@ const checkStepCompletion = async () => {
 
       if (tokenResponse.code === RESPONSE_CODE.REAUTH_REQUIRED) {
         console.warn('Reauth required, redirecting to Spotify OAuth...')
-        await redirectToSpotifyReauth()
+        redirectToSpotifyReauth()
         return
       }
 


### PR DESCRIPTION
將 `clearSpotifyCache` 更名為 `clearAllCache` 並擴展其功能，
使其清除所有 `sessionStorage`。此變更確保在重新驗證時能更
徹底地清除所有相關快取，避免資料不一致問題。

重構 `redirectToSpotifyReauth` 函數，使其不再是異步函數，
並導向至本地的 `/spotify-pre-auth` 路徑。此變更簡化了
重新驗證流程，將獲取Spotify授權URL的邏輯集中到
`/spotify-pre-auth` 視圖中處理，提高模組化和可維護性。

同時，移除所有呼叫 `redirectToSpotifyReauth` 處的 `await`
關鍵字，以符合其同步函數的行為。